### PR TITLE
Return unwrapping error when executing Do func

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -63,7 +63,7 @@ func Do(ctx context.Context, b Backoff, f RetryFunc) error {
 
 		next, stop := b.Next()
 		if stop {
-			return err
+			return errors.Unwrap(err)
 		}
 
 		select {

--- a/retry_test.go
+++ b/retry_test.go
@@ -23,6 +23,23 @@ func TestRetryableError(t *testing.T) {
 func TestDo(t *testing.T) {
 	t.Parallel()
 
+	t.Run("unwrapping_error", func(t *testing.T) {
+		t.Parallel()
+
+		b := retry.BackoffFunc(func() (time.Duration, bool) {
+			return 1 * time.Nanosecond, true
+		})
+		cause := fmt.Errorf("oops")
+
+		ctx := context.Background()
+		err := retry.Do(ctx, retry.WithMaxRetries(1, b), func(_ context.Context) error {
+			return retry.RetryableError(cause)
+		})
+		if err != cause {
+			t.Errorf("expected %v to be %v", err, cause)
+		}
+	})
+
 	t.Run("exit_on_max_attempt", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Changed returned error in retry.Do() `retryableError` to `unwrapping error`.

In my case, i use `retry.Do()` func like below to get origin error.

```
err := retry.Do(context.Background(), b, func(ctx context.Context) error {
  // my logic
})
if err != nil {
  if err2 := errors.Unwrap(err); err2 != nil {
    err = err2
  }
}
```

I think it is also helpful if u provide unwrapping errors in retry packages :)