### PR TITLE
feat: use error information to calculate backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,15 @@ value.
 ```golang
 b := NewFibonacci(1 * time.Second)
 
-// Return the next value, +/- 500ms
-b = WithJitter(500*time.Millisecond, b)
+// Add up to ±500ms jitter to the result
+b = WithJitter(500*time.Millisecond, false, b)
+// Increase the result by up to +500ms
+b = WithJitter(500*time.Millisecond, true, b)
 
-// Return the next value, +/- 5% of the result
-b = WithJitterPercent(5, b)
+// Add up to ±5% jitter to the result
+b = WithJitterPercent(5, false, b)
+// Increase the result by up to +5%
+b = WithJitterPercent(5, true, b)
 ```
 
 ### MaxRetries

--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ func WithHTTPResponse(next retry.Backoff) retry.Backoff {
 	return retry.BackoffFunc(func(err error) (time.Duration, error) {
 		var herr *httpRetryableError
 		if !errors.As(err, &herr) {
-			return -1, err
+			return retry.Stop, err
 		}
 		err = herr.Unwrap()
 
 		// get the values from the other backoff middleware (here just exponential backoff)
 		delay, err := next.Next(err)
-		if delay < 0 {
-			return -1, err
+		if retry.IsStopped(delay) {
+			return retry.Stop, err
 		}
 
 		// handle backoff with extra information from response

--- a/backoff.go
+++ b/backoff.go
@@ -33,17 +33,17 @@ func (b BackoffFunc) Next(err error) (time.Duration, error) {
 // never be less than 0.
 func WithJitter(j time.Duration, next Backoff) Backoff {
 	return BackoffFunc(func(err error) (time.Duration, error) {
-		val, err := next.Next(err)
-		if val < 0 {
+		delay, err := next.Next(err)
+		if delay < 0 {
 			return -1, err
 		}
 
 		diff := time.Duration(rand.Int63n(int64(j)*2) - int64(j))
-		val = val + diff
-		if val < 0 {
-			val = 0
+		delay = delay + diff
+		if delay < 0 {
+			delay = 0
 		}
-		return val, err
+		return delay, err
 	})
 }
 
@@ -53,8 +53,8 @@ func WithJitter(j time.Duration, next Backoff) Backoff {
 // value can never be less than 0 or greater than 100.
 func WithJitterPercent(j uint64, next Backoff) Backoff {
 	return BackoffFunc(func(err error) (time.Duration, error) {
-		val, err := next.Next(err)
-		if val < 0 {
+		delay, err := next.Next(err)
+		if delay < 0 {
 			return -1, err
 		}
 
@@ -62,11 +62,11 @@ func WithJitterPercent(j uint64, next Backoff) Backoff {
 		top := rand.Int63n(int64(j)*2) - int64(j)
 		pct := 1 - float64(top)/100.0
 
-		val = time.Duration(float64(val) * pct)
-		if val < 0 {
-			val = 0
+		delay = time.Duration(float64(delay) * pct)
+		if delay < 0 {
+			delay = 0
 		}
-		return val, err
+		return delay, err
 	})
 }
 
@@ -94,15 +94,15 @@ func WithMaxRetries(max uint64, next Backoff) Backoff {
 // continue infinitely.
 func WithCappedDuration(cap time.Duration, next Backoff) Backoff {
 	return BackoffFunc(func(err error) (time.Duration, error) {
-		val, err := next.Next(err)
-		if val < 0 {
+		delay, err := next.Next(err)
+		if delay < 0 {
 			return -1, err
 		}
 
-		if val <= 0 || val > cap {
-			val = cap
+		if delay <= 0 || delay > cap {
+			delay = cap
 		}
-		return val, err
+		return delay, err
 	})
 }
 
@@ -118,15 +118,15 @@ func WithMaxDuration(timeout time.Duration, next Backoff) Backoff {
 			return -1, err
 		}
 
-		val, err := next.Next(err)
-		if val < 0 {
+		delay, err := next.Next(err)
+		if delay < 0 {
 			return -1, err
 		}
 
-		if val <= 0 || val > diff {
-			val = diff
+		if delay <= 0 || delay > diff {
+			delay = diff
 		}
-		return val, err
+		return delay, err
 	})
 }
 

--- a/backoff.go
+++ b/backoff.go
@@ -1,6 +1,7 @@
 package retry
 
 import (
+	"errors"
 	"math/rand"
 	"sync"
 	"time"
@@ -12,18 +13,18 @@ func init() {
 
 // Backoff is an interface that backs off.
 type Backoff interface {
-	// Next returns the time duration to wait and whether to stop.
-	Next() (next time.Duration, stop bool)
+	// Next takes the error and returns the time duration to wait and the
+	// processed error. A duration less than zero signals the backoff to stop
+	// and to not retry again.
+	Next(err error) (time.Duration, error)
 }
 
-var _ Backoff = (BackoffFunc)(nil)
-
 // BackoffFunc is a backoff expressed as a function.
-type BackoffFunc func() (time.Duration, bool)
+type BackoffFunc func(err error) (time.Duration, error)
 
 // Next implements Backoff.
-func (b BackoffFunc) Next() (time.Duration, bool) {
-	return b()
+func (b BackoffFunc) Next(err error) (time.Duration, error) {
+	return b(err)
 }
 
 // WithJitter wraps a backoff function and adds the specified jitter. j can be
@@ -31,10 +32,10 @@ func (b BackoffFunc) Next() (time.Duration, bool) {
 // returned 20s, the value could be between 15 and 25 seconds. The value can
 // never be less than 0.
 func WithJitter(j time.Duration, next Backoff) Backoff {
-	return BackoffFunc(func() (time.Duration, bool) {
-		val, stop := next.Next()
-		if stop {
-			return 0, true
+	return BackoffFunc(func(err error) (time.Duration, error) {
+		val, err := next.Next(err)
+		if val < 0 {
+			return -1, err
 		}
 
 		diff := time.Duration(rand.Int63n(int64(j)*2) - int64(j))
@@ -42,7 +43,7 @@ func WithJitter(j time.Duration, next Backoff) Backoff {
 		if val < 0 {
 			val = 0
 		}
-		return val, false
+		return val, err
 	})
 }
 
@@ -51,10 +52,10 @@ func WithJitter(j time.Duration, next Backoff) Backoff {
 // the backoff returned 20s, the value could be between 19 and 21 seconds. The
 // value can never be less than 0 or greater than 100.
 func WithJitterPercent(j uint64, next Backoff) Backoff {
-	return BackoffFunc(func() (time.Duration, bool) {
-		val, stop := next.Next()
-		if stop {
-			return 0, true
+	return BackoffFunc(func(err error) (time.Duration, error) {
+		val, err := next.Next(err)
+		if val < 0 {
+			return -1, err
 		}
 
 		// Get a value between -j and j, the convert to a percentage
@@ -65,7 +66,7 @@ func WithJitterPercent(j uint64, next Backoff) Backoff {
 		if val < 0 {
 			val = 0
 		}
-		return val, false
+		return val, err
 	})
 }
 
@@ -74,21 +75,16 @@ func WithMaxRetries(max uint64, next Backoff) Backoff {
 	var l sync.Mutex
 	var attempt uint64
 
-	return BackoffFunc(func() (time.Duration, bool) {
+	return BackoffFunc(func(err error) (time.Duration, error) {
 		l.Lock()
 		defer l.Unlock()
 
 		if attempt >= max {
-			return 0, true
+			return -1, err
 		}
 		attempt++
 
-		val, stop := next.Next()
-		if stop {
-			return 0, true
-		}
-
-		return val, false
+		return next.Next(err)
 	})
 }
 
@@ -97,16 +93,16 @@ func WithMaxRetries(max uint64, next Backoff) Backoff {
 // value a backoff can return. Without another middleware, the backoff will
 // continue infinitely.
 func WithCappedDuration(cap time.Duration, next Backoff) Backoff {
-	return BackoffFunc(func() (time.Duration, bool) {
-		val, stop := next.Next()
-		if stop {
-			return 0, true
+	return BackoffFunc(func(err error) (time.Duration, error) {
+		val, err := next.Next(err)
+		if val < 0 {
+			return -1, err
 		}
 
 		if val <= 0 || val > cap {
 			val = cap
 		}
-		return val, false
+		return val, err
 	})
 }
 
@@ -116,20 +112,57 @@ func WithCappedDuration(cap time.Duration, next Backoff) Backoff {
 func WithMaxDuration(timeout time.Duration, next Backoff) Backoff {
 	start := time.Now()
 
-	return BackoffFunc(func() (time.Duration, bool) {
+	return BackoffFunc(func(err error) (time.Duration, error) {
 		diff := timeout - time.Since(start)
 		if diff <= 0 {
-			return 0, true
+			return -1, err
 		}
 
-		val, stop := next.Next()
-		if stop {
-			return 0, true
+		val, err := next.Next(err)
+		if val < 0 {
+			return -1, err
 		}
 
 		if val <= 0 || val > diff {
 			val = diff
 		}
-		return val, false
+		return val, err
+	})
+}
+
+type retryableError struct {
+	err error
+}
+
+// RetryableError marks an error as retryable.
+func RetryableError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &retryableError{err}
+}
+
+// Unwrap implements error wrapping.
+func (e *retryableError) Unwrap() error {
+	return e.err
+}
+
+// Error returns the error string.
+func (e *retryableError) Error() string {
+	if e.err == nil {
+		return "retryable: <nil>"
+	}
+	return "retryable: " + e.err.Error()
+}
+
+// WithRetryable wraps a backoff function and adds a check for a RetryableError.
+// When a non RetryableError then no more retry is performed.
+func WithRetryable(next Backoff) Backoff {
+	return BackoffFunc(func(err error) (time.Duration, error) {
+		var rerr *retryableError
+		if !errors.As(err, &rerr) {
+			return -1, err
+		}
+		return next.Next(rerr.Unwrap())
 	})
 }

--- a/backoff.go
+++ b/backoff.go
@@ -86,7 +86,7 @@ func WithJitterPercent(j uint64, addOnly bool, next Backoff) Backoff {
 			// get random value between -j and +j
 			top = rand.Int63n(int64(j)*2) - int64(j)
 		}
-		pct := 1 - float64(top)/100.0
+		pct := 1 + float64(top)/100.0
 
 		delay = time.Duration(float64(delay) * pct)
 		if delay < 0 {

--- a/backoff_constant.go
+++ b/backoff_constant.go
@@ -19,7 +19,7 @@ func NewConstant(t time.Duration) Backoff {
 		panic("t must be greater than 0")
 	}
 
-	return BackoffFunc(func() (time.Duration, bool) {
-		return t, false
+	return BackoffFunc(func(err error) (time.Duration, error) {
+		return t, err
 	})
 }

--- a/backoff_constant_test.go
+++ b/backoff_constant_test.go
@@ -73,7 +73,7 @@ func TestConstantBackoff(t *testing.T) {
 			resultsCh := make(chan time.Duration, tc.tries)
 			for i := 0; i < tc.tries; i++ {
 				go func() {
-					r, _ := b.Next()
+					r, _ := b.Next(nil)
 					resultsCh <- r
 				}()
 			}
@@ -81,8 +81,8 @@ func TestConstantBackoff(t *testing.T) {
 			results := make([]time.Duration, tc.tries)
 			for i := 0; i < tc.tries; i++ {
 				select {
-				case val := <-resultsCh:
-					results[i] = val
+				case delay := <-resultsCh:
+					results[i] = delay
 				case <-time.After(5 * time.Second):
 					t.Fatal("timeout")
 				}
@@ -102,8 +102,8 @@ func ExampleNewConstant() {
 	b := retry.NewConstant(1 * time.Second)
 
 	for i := 0; i < 5; i++ {
-		val, _ := b.Next()
-		fmt.Printf("%v\n", val)
+		delay, _ := b.Next(nil)
+		fmt.Printf("%v\n", delay)
 	}
 	// Output:
 	// 1s

--- a/backoff_exponential.go
+++ b/backoff_exponential.go
@@ -36,12 +36,12 @@ func NewExponential(base time.Duration) Backoff {
 }
 
 // Next implements Backoff. It is safe for concurrent use.
-func (b *exponentialBackoff) Next() (time.Duration, bool) {
+func (b *exponentialBackoff) Next(err error) (time.Duration, error) {
 	next := b.base << (atomic.AddUint64(&b.attempt, 1) - 1)
 	if next <= 0 {
 		atomic.AddUint64(&b.attempt, ^uint64(0))
 		next = math.MaxInt64
 	}
 
-	return next, false
+	return next, err
 }

--- a/backoff_exponential_test.go
+++ b/backoff_exponential_test.go
@@ -79,7 +79,7 @@ func TestExponentialBackoff(t *testing.T) {
 			resultsCh := make(chan time.Duration, tc.tries)
 			for i := 0; i < tc.tries; i++ {
 				go func() {
-					r, _ := b.Next()
+					r, _ := b.Next(nil)
 					resultsCh <- r
 				}()
 			}
@@ -87,8 +87,8 @@ func TestExponentialBackoff(t *testing.T) {
 			results := make([]time.Duration, tc.tries)
 			for i := 0; i < tc.tries; i++ {
 				select {
-				case val := <-resultsCh:
-					results[i] = val
+				case delay := <-resultsCh:
+					results[i] = delay
 				case <-time.After(5 * time.Second):
 					t.Fatal("timeout")
 				}
@@ -108,8 +108,8 @@ func ExampleNewExponential() {
 	b := retry.NewExponential(1 * time.Second)
 
 	for i := 0; i < 5; i++ {
-		val, _ := b.Next()
-		fmt.Printf("%v\n", val)
+		delay, _ := b.Next(nil)
+		fmt.Printf("%v\n", delay)
 	}
 	// Output:
 	// 1s

--- a/backoff_fibonacci.go
+++ b/backoff_fibonacci.go
@@ -39,18 +39,18 @@ func NewFibonacci(base time.Duration) Backoff {
 }
 
 // Next implements Backoff. It is safe for concurrent use.
-func (b *fibonacciBackoff) Next() (time.Duration, bool) {
+func (b *fibonacciBackoff) Next(err error) (time.Duration, error) {
 	for {
 		curr := atomic.LoadPointer(&b.state)
 		currState := (*state)(curr)
 		next := currState[0] + currState[1]
 
 		if next <= 0 {
-			return math.MaxInt64, false
+			return math.MaxInt64, err
 		}
 
 		if atomic.CompareAndSwapPointer(&b.state, curr, unsafe.Pointer(&state{currState[1], next})) {
-			return next, false
+			return next, err
 		}
 	}
 }

--- a/backoff_fibonacci_test.go
+++ b/backoff_fibonacci_test.go
@@ -91,7 +91,7 @@ func TestFibonacciBackoff(t *testing.T) {
 			resultsCh := make(chan time.Duration, tc.tries)
 			for i := 0; i < tc.tries; i++ {
 				go func() {
-					r, _ := b.Next()
+					r, _ := b.Next(nil)
 					resultsCh <- r
 				}()
 			}
@@ -99,8 +99,8 @@ func TestFibonacciBackoff(t *testing.T) {
 			results := make([]time.Duration, tc.tries)
 			for i := 0; i < tc.tries; i++ {
 				select {
-				case val := <-resultsCh:
-					results[i] = val
+				case delay := <-resultsCh:
+					results[i] = delay
 				case <-time.After(5 * time.Second):
 					t.Fatal("timeout")
 				}
@@ -120,8 +120,8 @@ func ExampleNewFibonacci() {
 	b := retry.NewFibonacci(1 * time.Second)
 
 	for i := 0; i < 5; i++ {
-		val, _ := b.Next()
-		fmt.Printf("%v\n", val)
+		delay, _ := b.Next(nil)
+		fmt.Printf("%v\n", delay)
 	}
 	// Output:
 	// 1s

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -43,8 +43,8 @@ func ExampleBackoffFunc() {
 func TestWithJitter(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 100_000; i++ {
-		b := retry.WithJitter(250*time.Millisecond, retry.BackoffFunc(func(err error) (time.Duration, error) {
+	for i := 0; i < 10_000; i++ {
+		b := retry.WithJitter(250*time.Millisecond, false, retry.BackoffFunc(func(err error) (time.Duration, error) {
 			return 1 * time.Second, err
 		}))
 		delay, _ := b.Next(nil)
@@ -56,13 +56,27 @@ func TestWithJitter(t *testing.T) {
 			t.Errorf("expected %v to be between %v and %v", delay, min, max)
 		}
 	}
+
+	for i := 0; i < 10_000; i++ {
+		b := retry.WithJitter(500*time.Millisecond, true, retry.BackoffFunc(func(err error) (time.Duration, error) {
+			return 1 * time.Second, err
+		}))
+		delay, _ := b.Next(nil)
+		if retry.IsStopped(delay) {
+			t.Errorf("should not stop")
+		}
+
+		if min, max := 1000*time.Millisecond, 1500*time.Millisecond; delay < min || delay > max {
+			t.Errorf("expected %v to be between %v and %v", delay, min, max)
+		}
+	}
 }
 
 func ExampleWithJitter() {
 	ctx := context.Background()
 
 	b := retry.NewFibonacci(1 * time.Second)
-	b = retry.WithJitter(1*time.Second, b)
+	b = retry.WithJitter(1*time.Second, false, b)
 
 	if err := retry.Do(ctx, b, func(_ context.Context) error {
 		// TODO: logic here
@@ -75,8 +89,8 @@ func ExampleWithJitter() {
 func TestWithJitterPercent(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 100_000; i++ {
-		b := retry.WithJitterPercent(5, retry.BackoffFunc(func(err error) (time.Duration, error) {
+	for i := 0; i < 10_000; i++ {
+		b := retry.WithJitterPercent(5, false, retry.BackoffFunc(func(err error) (time.Duration, error) {
 			return 1 * time.Second, err
 		}))
 		delay, _ := b.Next(nil)
@@ -88,13 +102,27 @@ func TestWithJitterPercent(t *testing.T) {
 			t.Errorf("expected %v to be between %v and %v", delay, min, max)
 		}
 	}
+
+	for i := 0; i < 10_000; i++ {
+		b := retry.WithJitterPercent(5, true, retry.BackoffFunc(func(err error) (time.Duration, error) {
+			return 1 * time.Second, err
+		}))
+		delay, _ := b.Next(nil)
+		if retry.IsStopped(delay) {
+			t.Errorf("should not stop")
+		}
+
+		if min, max := 1000*time.Millisecond, 1050*time.Millisecond; delay < min || delay > max {
+			t.Errorf("expected %v to be between %v and %v", delay, min, max)
+		}
+	}
 }
 
 func ExampleWithJitterPercent() {
 	ctx := context.Background()
 
 	b := retry.NewFibonacci(1 * time.Second)
-	b = retry.WithJitterPercent(5, b)
+	b = retry.WithJitterPercent(5, false, b)
 
 	if err := retry.Do(ctx, b, func(_ context.Context) error {
 		// TODO: logic here

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -2,6 +2,12 @@ package retry_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -13,12 +19,12 @@ func ExampleBackoffFunc() {
 
 	// Example backoff middleware that adds the provided duration t to the result.
 	withShift := func(t time.Duration, next retry.Backoff) retry.BackoffFunc {
-		return func() (time.Duration, bool) {
-			val, stop := next.Next()
-			if stop {
-				return 0, true
+		return func(err error) (time.Duration, error) {
+			delay, err := next.Next(err)
+			if delay < 0 {
+				return -1, err
 			}
-			return val + t, false
+			return delay + t, err
 		}
 	}
 
@@ -38,16 +44,16 @@ func TestWithJitter(t *testing.T) {
 	t.Parallel()
 
 	for i := 0; i < 100_000; i++ {
-		b := retry.WithJitter(250*time.Millisecond, retry.BackoffFunc(func() (time.Duration, bool) {
-			return 1 * time.Second, false
+		b := retry.WithJitter(250*time.Millisecond, retry.BackoffFunc(func(err error) (time.Duration, error) {
+			return 1 * time.Second, err
 		}))
-		val, stop := b.Next()
-		if stop {
+		delay, _ := b.Next(nil)
+		if delay < 0 {
 			t.Errorf("should not stop")
 		}
 
-		if min, max := 750*time.Millisecond, 1250*time.Millisecond; val < min || val > max {
-			t.Errorf("expected %v to be between %v and %v", val, min, max)
+		if min, max := 750*time.Millisecond, 1250*time.Millisecond; delay < min || delay > max {
+			t.Errorf("expected %v to be between %v and %v", delay, min, max)
 		}
 	}
 }
@@ -70,16 +76,16 @@ func TestWithJitterPercent(t *testing.T) {
 	t.Parallel()
 
 	for i := 0; i < 100_000; i++ {
-		b := retry.WithJitterPercent(5, retry.BackoffFunc(func() (time.Duration, bool) {
-			return 1 * time.Second, false
+		b := retry.WithJitterPercent(5, retry.BackoffFunc(func(err error) (time.Duration, error) {
+			return 1 * time.Second, err
 		}))
-		val, stop := b.Next()
-		if stop {
+		delay, _ := b.Next(nil)
+		if delay < 0 {
 			t.Errorf("should not stop")
 		}
 
-		if min, max := 950*time.Millisecond, 1050*time.Millisecond; val < min || val > max {
-			t.Errorf("expected %v to be between %v and %v", val, min, max)
+		if min, max := 950*time.Millisecond, 1050*time.Millisecond; delay < min || delay > max {
+			t.Errorf("expected %v to be between %v and %v", delay, min, max)
 		}
 	}
 }
@@ -101,28 +107,25 @@ func ExampleWithJitterPercent() {
 func TestWithMaxRetries(t *testing.T) {
 	t.Parallel()
 
-	b := retry.WithMaxRetries(3, retry.BackoffFunc(func() (time.Duration, bool) {
-		return 1 * time.Second, false
+	b := retry.WithMaxRetries(3, retry.BackoffFunc(func(err error) (time.Duration, error) {
+		return 1 * time.Second, err
 	}))
 
 	// First 3 attempts succeed
 	for i := 0; i < 3; i++ {
-		val, stop := b.Next()
-		if stop {
+		delay, _ := b.Next(nil)
+		if delay < 0 {
 			t.Errorf("should not stop")
 		}
-		if val != 1*time.Second {
-			t.Errorf("expected %v to be %v", val, 1*time.Second)
+		if delay != 1*time.Second {
+			t.Errorf("expected %v to be %v", delay, 1*time.Second)
 		}
 	}
 
 	// Now we stop
-	val, stop := b.Next()
-	if !stop {
+	delay, _ := b.Next(nil)
+	if delay >= 0 {
 		t.Errorf("should stop")
-	}
-	if val != 0 {
-		t.Errorf("expected %v to be %v", val, 0)
 	}
 }
 
@@ -143,16 +146,16 @@ func ExampleWithMaxRetries() {
 func TestWithCappedDuration(t *testing.T) {
 	t.Parallel()
 
-	b := retry.WithCappedDuration(3*time.Second, retry.BackoffFunc(func() (time.Duration, bool) {
-		return 5 * time.Second, false
+	b := retry.WithCappedDuration(3*time.Second, retry.BackoffFunc(func(err error) (time.Duration, error) {
+		return 5 * time.Second, err
 	}))
 
-	val, stop := b.Next()
-	if stop {
+	delay, _ := b.Next(nil)
+	if delay < 0 {
 		t.Errorf("should not stop")
 	}
-	if val != 3*time.Second {
-		t.Errorf("expected %v to be %v", val, 3*time.Second)
+	if delay != 3*time.Second {
+		t.Errorf("expected %v to be %v", delay, 3*time.Second)
 	}
 }
 
@@ -173,41 +176,38 @@ func ExampleWithCappedDuration() {
 func TestWithMaxDuration(t *testing.T) {
 	t.Parallel()
 
-	b := retry.WithMaxDuration(250*time.Millisecond, retry.BackoffFunc(func() (time.Duration, bool) {
-		return 1 * time.Second, false
+	b := retry.WithMaxDuration(250*time.Millisecond, retry.BackoffFunc(func(err error) (time.Duration, error) {
+		return 1 * time.Second, err
 	}))
 
 	// Take once, within timeout.
-	val, stop := b.Next()
-	if stop {
+	delay, _ := b.Next(nil)
+	if delay < 0 {
 		t.Error("should not stop")
 	}
 
-	if val > 250*time.Millisecond {
-		t.Errorf("expected %v to be less than %v", val, 250*time.Millisecond)
+	if delay > 250*time.Millisecond {
+		t.Errorf("expected %v to be less than %v", delay, 250*time.Millisecond)
 	}
 
 	time.Sleep(200 * time.Millisecond)
 
 	// Take again, remainder contines
-	val, stop = b.Next()
-	if stop {
+	delay, _ = b.Next(nil)
+	if delay < 0 {
 		t.Error("should not stop")
 	}
 
-	if val > 50*time.Millisecond {
-		t.Errorf("expected %v to be less than %v", val, 50*time.Millisecond)
+	if delay > 50*time.Millisecond {
+		t.Errorf("expected %v to be less than %v", delay, 50*time.Millisecond)
 	}
 
 	time.Sleep(50 * time.Millisecond)
 
 	// Now we stop
-	val, stop = b.Next()
-	if !stop {
+	delay, _ = b.Next(nil)
+	if delay >= 0 {
 		t.Errorf("should stop")
-	}
-	if val != 0 {
-		t.Errorf("expected %v to be %v", val, 0)
 	}
 }
 
@@ -222,5 +222,99 @@ func ExampleWithMaxDuration() {
 		return nil
 	}); err != nil {
 		// handle error
+	}
+}
+
+type httpRetryableError struct {
+	err  error
+	resp http.Response
+}
+
+func (e *httpRetryableError) Unwrap() error {
+	return e.err
+}
+
+func (e *httpRetryableError) Error() string {
+	return e.err.Error()
+}
+
+func TestWithCustom(t *testing.T) {
+	WithHTTPResponse := func(next retry.Backoff) retry.Backoff {
+		return retry.BackoffFunc(func(err error) (time.Duration, error) {
+			var herr *httpRetryableError
+			if !errors.As(err, &herr) {
+				return -1, err
+			}
+			err = herr.Unwrap()
+
+			delay, err := next.Next(err)
+			if delay < 0 {
+				return -1, err
+			}
+
+			switch herr.resp.StatusCode {
+			case 427:
+				retryAfter, err := strconv.Atoi(herr.resp.Header.Get("Retry-After"))
+				if err != nil {
+					retryAfter = 10
+				}
+				delay = time.Duration(retryAfter) * time.Second
+			case 500:
+				delay = 2 * time.Second
+			}
+
+			// return backoff calculated by other wrappers
+			return delay, err
+		})
+	}
+
+	ctx := context.Background()
+
+	b := retry.NewExponential(1 * time.Second)
+	b = WithHTTPResponse(b)
+
+	reqCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reqCount == 0 {
+			w.Header().Add("Retry-After", "1")
+			w.WriteHeader(427)
+		} else if reqCount == 1 {
+			w.WriteHeader(500)
+		} else {
+			fmt.Fprintln(w, "hello")
+		}
+		reqCount++
+	}))
+	defer ts.Close()
+
+	var body []byte
+
+	err := retry.Do(ctx, b, func(_ context.Context) error {
+		resp, err := http.Get(ts.URL)
+
+		if err == nil {
+			if resp.StatusCode != 200 {
+				return &httpRetryableError{
+					err:  err,
+					resp: *resp,
+				}
+			}
+
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					panic(err)
+				}
+			}()
+			body, err = ioutil.ReadAll(resp.Body)
+		}
+
+		return err
+	})
+
+	if err != nil {
+		t.Errorf("expected no error")
+	}
+	if len(body) == 0 {
+		t.Errorf("expected non empty body")
 	}
 }

--- a/retry.go
+++ b/retry.go
@@ -37,7 +37,7 @@ func Do(ctx context.Context, b Backoff, f RetryFunc) error {
 		}
 
 		delay, err := b.Next(err)
-		if delay < 0 {
+		if IsStopped(delay) {
 			return err
 		}
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -194,7 +194,7 @@ func TestCancel(t *testing.T) {
 		b = retry.WithMaxRetries(maxRetries, b)
 
 		const jitter time.Duration = 5 * time.Millisecond
-		b = retry.WithJitter(jitter, b)
+		b = retry.WithJitter(jitter, false, b)
 
 		// Here we cancel the Context *before* the call to Do
 		cancel()

--- a/retry_test.go
+++ b/retry_test.go
@@ -29,8 +29,8 @@ func TestDo(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
-		b := retry.WithMaxRetries(3, retry.BackoffFunc(func() (time.Duration, bool) {
-			return 1 * time.Nanosecond, false
+		b := retry.WithMaxRetries(3, retry.BackoffFunc(func(err error) (time.Duration, error) {
+			return 1 * time.Nanosecond, err
 		}))
 
 		var i int
@@ -51,9 +51,9 @@ func TestDo(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
-		b := retry.WithMaxRetries(3, retry.BackoffFunc(func() (time.Duration, bool) {
-			return 1 * time.Nanosecond, false
-		}))
+		b := retry.WithRetryable(retry.WithMaxRetries(3, retry.BackoffFunc(func(err error) (time.Duration, error) {
+			return 1 * time.Nanosecond, err
+		})))
 
 		var i int
 		if err := retry.Do(ctx, b, func(_ context.Context) error {
@@ -72,9 +72,9 @@ func TestDo(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
-		b := retry.WithMaxRetries(1, retry.BackoffFunc(func() (time.Duration, bool) {
-			return 1 * time.Nanosecond, false
-		}))
+		b := retry.WithRetryable(retry.WithMaxRetries(1, retry.BackoffFunc(func(err error) (time.Duration, error) {
+			return 1 * time.Nanosecond, err
+		})))
 
 		err := retry.Do(ctx, b, func(_ context.Context) error {
 			return retry.RetryableError(io.EOF)
@@ -92,8 +92,8 @@ func TestDo(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
-		b := retry.WithMaxRetries(3, retry.BackoffFunc(func() (time.Duration, bool) {
-			return 1 * time.Nanosecond, false
+		b := retry.WithMaxRetries(3, retry.BackoffFunc(func(err error) (time.Duration, error) {
+			return 1 * time.Nanosecond, err
 		}))
 
 		var i int
@@ -112,8 +112,8 @@ func TestDo(t *testing.T) {
 	t.Run("context_canceled", func(t *testing.T) {
 		t.Parallel()
 
-		b := retry.BackoffFunc(func() (time.Duration, bool) {
-			return 5 * time.Second, false
+		b := retry.BackoffFunc(func(err error) (time.Duration, error) {
+			return 5 * time.Second, err
 		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)


### PR DESCRIPTION
I like the implementation concept of go-retry, but it doesn't support backoff calculation based on the response. My use case: Calculate the backoff delay based on different HTTP responses. For example a 427 HTTP response would take the "Retry-After" header into consideration while a 5XX response would do something different.

Essentially I changed the `Backoff` interface as such:

```go
type Backoff interface {
	// Next takes the error and returns the time duration to wait and the
	// processed error. A duration less than zero signals the backoff to stop
	// and to not retry again.
	Next(err error) (time.Duration, error)
}
```

This way the backoff calculation can work on error information (e.g. HTTP response information) and modify the (retry-)error if necessary.

There are some other changes mixed in this PR. I just thought I would show you, maybe you are interested into integrating stuff like this (I know it is quite a lot os changes...).