### PR TITLE
add blocking-rate-limiter backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ b := NewFibonacci(1 * time.Second)
 b = WithMaxDuration(5 * time.Second, b)
 ```
 
+### WithBlockingRateLimiter
+
+For use with a provided blocking rate-limiter on request scope. This is
+helpful for avoiding [retry-storms](https://docs.microsoft.com/en-us/azure/architecture/antipatterns/retry-storm/)
+across lifecyle of multiple requests:
+```golang
+b := NewFibonacci(1 * time.Second)
+
+// Implementation to be provided by you.
+// Ensure the rate limiter is blocking.
+// The config for rate and scope must be configured here.
+rl := RateLimiter()
+
+b = WithBlockingRateLimiter(rl, b)
+```
+
 ## Benchmarks
 
 Here are benchmarks against some other popular Go backoff and retry libraries.


### PR DESCRIPTION
Retry-Storms is a major problem in large companies using rery mechanism among services and cause a much bigger unavailability issue than without retrial logic. More details available here -
- [Retry Storm antipattern](https://docs.microsoft.com/en-us/azure/architecture/antipatterns/retry-storm/?ranMID=46131&ranEAID=a1LgFw09t88&ranSiteID=a1LgFw09t88-kGV2w0yG7ZUnx0rI4VFglw&epi=a1LgFw09t88-kGV2w0yG7ZUnx0rI4VFglw&irgwc=1&OCID=AID2200057_aff_7806_1243925&tduid=(ir__f1sdcqtte0kf6ytocwvoav9lr32xve9qm9c9atw200)(7806)(1243925)(a1LgFw09t88-kGV2w0yG7ZUnx0rI4VFglw)()&irclickid=_f1sdcqtte0kf6ytocwvoav9lr32xve9qm9c9atw200)
- [How To Avoid Retry Storms In Distributed Systems
](https://faun.pub/how-to-avoid-retry-storms-in-distributed-systems-91bf34f43c7f)

One posiible solution is to use a rate-limiter -
- Rate-limiter has an application wide scope, generally due to using a remote key-value data store such as Redis.
- Using them ensures that irrespective of number of requests coming from the client, retrial will be done only as per dedided rate.

Another solution can be circuit breaking but it is more complex than rate-limiting and needs to tewaked more finely to balance the right tradeoffs and hence less preferrable than this.

Rate limiter itself can have various implementations and hence has been kept as a separate interface for consumer of this library to define. 