### PR TITLE
backoff: remove global rand.Seed and using locked rand.Rand

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -1,6 +1,7 @@
 package retry
 
 import (
+	"math/rand"
 	"sync"
 	"time"
 )
@@ -26,6 +27,7 @@ func (b BackoffFunc) Next() (time.Duration, bool) {
 // returned 20s, the value could be between 15 and 25 seconds. The value can
 // never be less than 0.
 func WithJitter(j time.Duration, next Backoff) Backoff {
+	r := &lockedSource{src: rand.New(rand.NewSource(time.Now().UnixNano()))}
 	return BackoffFunc(func() (time.Duration, bool) {
 		val, stop := next.Next()
 		if stop {
@@ -46,6 +48,7 @@ func WithJitter(j time.Duration, next Backoff) Backoff {
 // the backoff returned 20s, the value could be between 19 and 21 seconds. The
 // value can never be less than 0 or greater than 100.
 func WithJitterPercent(j uint64, next Backoff) Backoff {
+	r := &lockedSource{src: rand.New(rand.NewSource(time.Now().UnixNano()))}
 	return BackoffFunc(func() (time.Duration, bool) {
 		val, stop := next.Next()
 		if stop {

--- a/backoff.go
+++ b/backoff.go
@@ -22,12 +22,9 @@ func (r *rng) Int63n(n int64) int64 {
 	if n <= 0 {
 		panic("invalid argument to Int63n")
 	}
-
-	// can mask if n is power of two
-	if n&(n-1) == 0 {
+	if n&(n-1) == 0 { // n is power of two, can mask
 		return r.Int63() & (n - 1)
 	}
-
 	max := int64((1 << 63) - 1 - (1<<63)%uint64(n))
 	v := r.Int63()
 	for v > max {

--- a/rand.go
+++ b/rand.go
@@ -1,0 +1,47 @@
+package retry
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var r = &lockedSource{src: rand.New(rand.NewSource(time.Now().UnixNano()))}
+
+type lockedSource struct {
+	lk  sync.Mutex
+	src *rand.Rand
+}
+
+var _ rand.Source = (*lockedSource)(nil)
+
+// Int63 mimics math/rand.(*Rand).Int63 with mutex locked.
+func (r *lockedSource) Int63() int64 {
+	r.lk.Lock()
+	n := r.src.Int63()
+	r.lk.Unlock()
+	return n
+}
+
+// Seed mimics math/rand.(*Rand).Seed with mutex locked.
+func (r *lockedSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
+}
+
+// Int63n mimics math/rand.(*Rand).Int63n with mutex locked.
+func (r *lockedSource) Int63n(n int64) int64 {
+	if n <= 0 {
+		panic("invalid argument to Int63n")
+	}
+	if n&(n-1) == 0 { // n is power of two, can mask
+		return r.Int63() & (n - 1)
+	}
+	max := int64((1 << 63) - 1 - (1<<63)%uint64(n))
+	v := r.Int63()
+	for v > max {
+		v = r.Int63()
+	}
+	return v % n
+}

--- a/rand.go
+++ b/rand.go
@@ -9,8 +9,8 @@ import (
 var r = &lockedSource{src: rand.New(rand.NewSource(time.Now().UnixNano()))}
 
 type lockedSource struct {
-	lk  sync.Mutex
 	src *rand.Rand
+	lk  sync.Mutex
 }
 
 var _ rand.Source = (*lockedSource)(nil)

--- a/rand.go
+++ b/rand.go
@@ -3,31 +3,34 @@ package retry
 import (
 	"math/rand"
 	"sync"
-	"time"
 )
-
-var r = &lockedSource{src: rand.New(rand.NewSource(time.Now().UnixNano()))}
 
 type lockedSource struct {
 	src *rand.Rand
 	lk  sync.Mutex
 }
 
-var _ rand.Source = (*lockedSource)(nil)
+var _ rand.Source64 = (*lockedSource)(nil)
 
 // Int63 mimics math/rand.(*Rand).Int63 with mutex locked.
 func (r *lockedSource) Int63() int64 {
 	r.lk.Lock()
-	n := r.src.Int63()
-	r.lk.Unlock()
-	return n
+	defer r.lk.Unlock()
+	return r.src.Int63()
 }
 
 // Seed mimics math/rand.(*Rand).Seed with mutex locked.
 func (r *lockedSource) Seed(seed int64) {
 	r.lk.Lock()
+	defer r.lk.Unlock()
 	r.src.Seed(seed)
-	r.lk.Unlock()
+}
+
+// Uint64 mimics math/rand.(*Rand).Uint64 with mutex locked.
+func (r *lockedSource) Uint64() uint64 {
+	r.lk.Lock()
+	defer r.lk.Unlock()
+	return r.src.Uint64()
 }
 
 // Int63n mimics math/rand.(*Rand).Int63n with mutex locked.


### PR DESCRIPTION
`rand.Seed` will affect globally. Remove it, and implements mutex locked `rand.Rand` similar of stdlib.