### PR TITLE
Allow constant backoff of zero seconds.

### DIFF
--- a/backoff_constant.go
+++ b/backoff_constant.go
@@ -15,7 +15,7 @@ func Constant(ctx context.Context, t time.Duration, f RetryFunc) error {
 // is the provided constant value. It panics if the given base is less than
 // zero.
 func NewConstant(t time.Duration) Backoff {
-	if t <= 0 {
+	if t < 0 {
 		panic("t must be greater than 0")
 	}
 


### PR DESCRIPTION
Seems like a valid use case to immediately retry with zero dely. The comments of this function seem to indicate that it should be less than zero as well.