### PR TITLE
feat: Add IsRetryable to check if error is retryable

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -49,6 +49,12 @@ func (e *retryableError) Error() string {
 	return "retryable: " + e.err.Error()
 }
 
+// IsRetryable returns true if the error is marked as retryable.
+func IsRetryable(err error) bool {
+	var rerr *retryableError
+	return errors.As(err, &rerr)
+}
+
 func DoValue[T any](ctx context.Context, b Backoff, f RetryFuncValue[T]) (T, error) {
 	var nilT T
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -22,6 +22,20 @@ func TestRetryableError(t *testing.T) {
 	}
 }
 
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	err1 := retry.RetryableError(fmt.Errorf("retryable"))
+	if !retry.IsRetryable(err1) {
+		t.Errorf("expected error to be retryable")
+	}
+
+	err2 := fmt.Errorf("not retryable")
+	if retry.IsRetryable(err2) {
+		t.Errorf("expected error to not be retryable")
+	}
+}
+
 func TestDoValue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Changes

This PR adds a simple `IsRetryable` function to check if an `error` is marked as retryable.

### Use case

Consider having a `retryFunc` that calls a transient function which returns an error that may or may not be marked as retryable. Within the `retryFunc` we want to log the error if it is retryable.