### PR TITLE
fix: avoid Int63n panic when jitter is zero

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -34,6 +34,10 @@ func WithJitter(j time.Duration, next Backoff) Backoff {
 			return 0, true
 		}
 
+		if j <= 0 {
+			return val, false
+		}
+
 		diff := time.Duration(r.Int63n(int64(j)*2) - int64(j))
 		val = val + diff
 		if val < 0 {
@@ -54,6 +58,10 @@ func WithJitterPercent(j uint64, next Backoff) Backoff {
 		val, stop := next.Next()
 		if stop {
 			return 0, true
+		}
+
+		if j == 0 {
+			return val, false
 		}
 
 		// Get a value between -j and j, the convert to a percentage

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -52,6 +52,21 @@ func TestWithJitter(t *testing.T) {
 	}
 }
 
+func TestWithJitter_Zero(t *testing.T) {
+	t.Parallel()
+
+	b := retry.WithJitter(0, retry.BackoffFunc(func() (time.Duration, bool) {
+		return 1 * time.Second, false
+	}))
+	val, stop := b.Next()
+	if stop {
+		t.Errorf("should not stop")
+	}
+	if val != 1*time.Second {
+		t.Errorf("expected %v to be %v", val, 1*time.Second)
+	}
+}
+
 func ExampleWithJitter() {
 	ctx := context.Background()
 
@@ -81,6 +96,21 @@ func TestWithJitterPercent(t *testing.T) {
 		if min, max := 950*time.Millisecond, 1050*time.Millisecond; val < min || val > max {
 			t.Errorf("expected %v to be between %v and %v", val, min, max)
 		}
+	}
+}
+
+func TestWithJitterPercent_Zero(t *testing.T) {
+	t.Parallel()
+
+	b := retry.WithJitterPercent(0, retry.BackoffFunc(func() (time.Duration, bool) {
+		return 1 * time.Second, false
+	}))
+	val, stop := b.Next()
+	if stop {
+		t.Errorf("should not stop")
+	}
+	if val != 1*time.Second {
+		t.Errorf("expected %v to be %v", val, 1*time.Second)
 	}
 }
 


### PR DESCRIPTION
`WithJitter(0, ...)` and `WithJitterPercent(0, ...)` panic with "invalid argument to Int63n" because `rand.Int63n` requires a positive argument. Passing zero is a reasonable way to express "no jitter", and a computed jitter value can legitimately be zero.

This returns the underlying backoff value unchanged when the jitter is zero. Added regression tests for both functions.