### PR TITLE
fix: avoid Int63n panic on non-positive jitter

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -60,7 +60,7 @@ func WithJitterPercent(j uint64, next Backoff) Backoff {
 			return 0, true
 		}
 
-		if j == 0 {
+		if j <= 0 {
 			return val, false
 		}
 

--- a/backoff.go
+++ b/backoff.go
@@ -34,6 +34,10 @@ func WithJitter(j time.Duration, next Backoff) Backoff {
 			return 0, true
 		}
 
+		if j <= 0 {
+			return val, false
+		}
+
 		diff := time.Duration(r.Int63n(int64(j)*2) - int64(j))
 		val = val + diff
 		if val < 0 {
@@ -54,6 +58,10 @@ func WithJitterPercent(j uint64, next Backoff) Backoff {
 		val, stop := next.Next()
 		if stop {
 			return 0, true
+		}
+
+		if j == 0 {
+			return val, false
 		}
 
 		// Get a value between -j and j, the convert to a percentage

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -52,18 +52,58 @@ func TestWithJitter(t *testing.T) {
 	}
 }
 
-func TestWithJitter_Zero(t *testing.T) {
+func TestWithJitter_NonPositive(t *testing.T) {
 	t.Parallel()
 
-	b := retry.WithJitter(0, retry.BackoffFunc(func() (time.Duration, bool) {
-		return 1 * time.Second, false
-	}))
-	val, stop := b.Next()
-	if stop {
-		t.Errorf("should not stop")
+	cases := []struct {
+		name     string
+		j        time.Duration
+		nextVal  time.Duration
+		nextStop bool
+		wantVal  time.Duration
+		wantStop bool
+	}{
+		{
+			name:    "zero",
+			j:       0,
+			nextVal: 1 * time.Second,
+			wantVal: 1 * time.Second,
+		},
+		{
+			name:    "negative",
+			j:       -5 * time.Second,
+			nextVal: 1 * time.Second,
+			wantVal: 1 * time.Second,
+		},
+		{
+			name:     "stop_propagates",
+			j:        0,
+			nextStop: true,
+			wantStop: true,
+		},
 	}
-	if val != 1*time.Second {
-		t.Errorf("expected %v to be %v", val, 1*time.Second)
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// A non-positive jitter must not panic (Int63n panics on a
+			// non-positive argument) and must return the underlying value
+			// unchanged.
+			b := retry.WithJitter(tc.j, retry.BackoffFunc(func() (time.Duration, bool) {
+				return tc.nextVal, tc.nextStop
+			}))
+
+			val, stop := b.Next()
+			if stop != tc.wantStop {
+				t.Errorf("expected stop to be %t", tc.wantStop)
+			}
+			if val != tc.wantVal {
+				t.Errorf("expected %v to be %v", val, tc.wantVal)
+			}
+		})
 	}
 }
 
@@ -102,15 +142,49 @@ func TestWithJitterPercent(t *testing.T) {
 func TestWithJitterPercent_Zero(t *testing.T) {
 	t.Parallel()
 
-	b := retry.WithJitterPercent(0, retry.BackoffFunc(func() (time.Duration, bool) {
-		return 1 * time.Second, false
-	}))
-	val, stop := b.Next()
-	if stop {
-		t.Errorf("should not stop")
+	// j is a uint64, so zero is the only non-positive value it can hold.
+	cases := []struct {
+		name     string
+		j        uint64
+		nextVal  time.Duration
+		nextStop bool
+		wantVal  time.Duration
+		wantStop bool
+	}{
+		{
+			name:    "zero",
+			j:       0,
+			nextVal: 1 * time.Second,
+			wantVal: 1 * time.Second,
+		},
+		{
+			name:     "stop_propagates",
+			j:        0,
+			nextStop: true,
+			wantStop: true,
+		},
 	}
-	if val != 1*time.Second {
-		t.Errorf("expected %v to be %v", val, 1*time.Second)
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// A zero jitter must not panic (Int63n panics on a non-positive
+			// argument) and must return the underlying value unchanged.
+			b := retry.WithJitterPercent(tc.j, retry.BackoffFunc(func() (time.Duration, bool) {
+				return tc.nextVal, tc.nextStop
+			}))
+
+			val, stop := b.Next()
+			if stop != tc.wantStop {
+				t.Errorf("expected stop to be %t", tc.wantStop)
+			}
+			if val != tc.wantVal {
+				t.Errorf("expected %v to be %v", val, tc.wantVal)
+			}
+		})
 	}
 }
 

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -52,6 +52,21 @@ func TestWithJitter(t *testing.T) {
 	}
 }
 
+func TestWithJitter_Zero(t *testing.T) {
+	t.Parallel()
+
+	b := retry.WithJitter(0, retry.BackoffFunc(func() (time.Duration, bool) {
+		return 1 * time.Second, false
+	}))
+	val, stop := b.Next()
+	if stop {
+		t.Errorf("should not stop")
+	}
+	if val != 1*time.Second {
+		t.Errorf("expected %v to be %v", val, 1*time.Second)
+	}
+}
+
 func ExampleWithJitter() {
 	ctx := context.Background()
 
@@ -81,6 +96,21 @@ func TestWithJitterPercent(t *testing.T) {
 		if min, max := 950*time.Millisecond, 1050*time.Millisecond; val < min || val > max {
 			t.Errorf("expected %v to be between %v and %v", val, min, max)
 		}
+	}
+}
+
+func TestWithJitterPercent_Zero(t *testing.T) {
+	t.Parallel()
+
+	b := retry.WithJitterPercent(0, retry.BackoffFunc(func() (time.Duration, bool) {
+		return 1 * time.Second, false
+	}))
+	val, stop := b.Next()
+	if stop {
+		t.Errorf("should not stop")
+	}
+	if val != 1*time.Second {
+		t.Errorf("expected %v to be %v", val, 1*time.Second)
 	}
 }
 


### PR DESCRIPTION
Both `WithJitter(0, ...)` and `WithJitterPercent(0, ...)` panic with "invalid argument to Int63n" because `rand.Int63n` requires a positive argument. Passing zero is a reasonable way to express "no jitter", and a computed jitter value can legitimately be zero. `WithJitter` additionally panics on a negative `time.Duration`.

Both middlewares now short-circuit when the jitter argument is non-positive (`j <= 0`) and return the underlying backoff value unchanged.

This builds on the original fix from @SAY-5 in https://github.com/sethvargo/go-retry/pull/37, whose commit is preserved here for attribution. On top of it, this makes the `WithJitterPercent` guard `<= 0` to match `WithJitter`, and expands the regression tests into table-driven subtests covering zero jitter, a negative `WithJitter` argument (which would otherwise panic in `Int63n`), and stop propagation through the guard.
