### PR TITLE
Cover backoff wrappers and constructor panics

### DIFF
--- a/backoff_constant_test.go
+++ b/backoff_constant_test.go
@@ -1,6 +1,8 @@
 package retry_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -107,4 +109,47 @@ func ExampleNewConstant() {
 	// 1s
 	// 1s
 	// 1s
+}
+
+func TestConstant(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	if err := retry.Constant(context.Background(), 1*time.Nanosecond, func(_ context.Context) error {
+		calls++
+		if calls < 3 {
+			return retry.RetryableError(errors.New("retry"))
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 3 {
+		t.Errorf("expected %d to be %d", calls, 3)
+	}
+}
+
+func TestNewConstant_panics(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		base time.Duration
+	}{
+		{name: "zero", base: 0},
+		{name: "negative", base: -1 * time.Second},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected panic")
+				}
+			}()
+			retry.NewConstant(tc.base)
+		})
+	}
 }

--- a/backoff_exponential_test.go
+++ b/backoff_exponential_test.go
@@ -1,6 +1,8 @@
 package retry_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -156,5 +158,48 @@ func TestExponentialBackoff_ConcurrentOverflow(t *testing.T) {
 
 	if !reflect.DeepEqual(results, want) {
 		t.Errorf("expected \n\n%v\n\n to be \n\n%v\n\n", results, want)
+	}
+}
+
+func TestExponential(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	if err := retry.Exponential(context.Background(), 1*time.Nanosecond, func(_ context.Context) error {
+		calls++
+		if calls < 3 {
+			return retry.RetryableError(errors.New("retry"))
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 3 {
+		t.Errorf("expected %d to be %d", calls, 3)
+	}
+}
+
+func TestNewExponential_panics(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		base time.Duration
+	}{
+		{name: "zero", base: 0},
+		{name: "negative", base: -1 * time.Second},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected panic")
+				}
+			}()
+			retry.NewExponential(tc.base)
+		})
 	}
 }

--- a/backoff_fibonacci_test.go
+++ b/backoff_fibonacci_test.go
@@ -1,6 +1,8 @@
 package retry_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -125,4 +127,47 @@ func ExampleNewFibonacci() {
 	// 3s
 	// 5s
 	// 8s
+}
+
+func TestFibonacci(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	if err := retry.Fibonacci(context.Background(), 1*time.Nanosecond, func(_ context.Context) error {
+		calls++
+		if calls < 3 {
+			return retry.RetryableError(errors.New("retry"))
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 3 {
+		t.Errorf("expected %d to be %d", calls, 3)
+	}
+}
+
+func TestNewFibonacci_panics(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		base time.Duration
+	}{
+		{name: "zero", base: 0},
+		{name: "negative", base: -1 * time.Second},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				if recover() == nil {
+					t.Errorf("expected panic")
+				}
+			}()
+			retry.NewFibonacci(tc.base)
+		})
+	}
 }


### PR DESCRIPTION
Adds test coverage for public API that had none, pulled from the non-nix parts of #38 and rewritten to match the per-source-file test layout.

The `Constant`, `Exponential`, and `Fibonacci` convenience wrappers were at 0% coverage, and the `NewConstant`/`NewExponential`/`NewFibonacci` non-positive-base panic paths were untested. Each `backoff_*_test.go` now exercises its wrapper (retry a few times, then succeed) and its constructor panics (table-driven over zero and negative bases).

Package coverage goes from 89.5% to 95.2%; the six functions above are now 100%.

Deliberately left out of #38: the nix tooling, the Go 1.26.5 bump (staying on 1.25), the jitter zero-panic fix (already landed in #39), the `lockedSource` tests (rand.go is gone), and `IsRetryable` (no external need today, and an `errors.Is`-friendly sentinel would beat a bool helper if one ever arises).
