### PR TITLE
Pin checkout and setup-go to v7 SHAs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # ratchet:actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: 'actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e' # ratchet:actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
 


### PR DESCRIPTION
Bumps `actions/checkout` (v4 -> v7) and `actions/setup-go` (v5 -> v7), and pins both to commit SHAs with ratchet.

The intervening majors are runtime (ESM/Node) and dependency bumps; nothing this workflow relies on changed. checkout v7 also blocks fork-PR checkout for `pull_request_target`/`workflow_run`, neither of which this workflow uses, and setup-go still reads `go-version-file`.

Pinning to a SHA runs an immutable, verified ref instead of a mutable tag; the `# ratchet:actions/...@v7` comment keeps the version readable and lets `ratchet update` bump it later. Verified both SHAs resolve to the current `v7` tags.