### PR TITLE
Add WithFullJitter backoff middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ b = WithJitter(500*time.Millisecond, b)
 
 // Return the next value, +/- 5% of the result
 b = WithJitterPercent(5, b)
+
+// Return a random value in [0, next value)
+b = WithFullJitter(b)
 ```
 
 ### MaxRetries

--- a/backoff.go
+++ b/backoff.go
@@ -67,6 +67,29 @@ func WithJitterPercent(j uint64, next Backoff) Backoff {
 	})
 }
 
+// WithFullJitter wraps a backoff function and returns a random value between
+// zero (inclusive) and the wrapped backoff's returned value (exclusive). For
+// example, if the backoff returned 20s, the value could be anywhere in [0, 20s).
+//
+// Unlike WithJitter, which applies "+/- j" around the value, full jitter
+// spreads the wait across the entire range, which spreads out retrying clients
+// more effectively. See
+// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/.
+func WithFullJitter(next Backoff) Backoff {
+	return BackoffFunc(func() (time.Duration, bool) {
+		val, stop := next.Next()
+		if stop {
+			return 0, true
+		}
+
+		if val <= 0 {
+			return val, false
+		}
+
+		return time.Duration(rand.Int64N(int64(val))), false
+	})
+}
+
 // WithMaxRetries executes the backoff function up until the maximum attempts.
 func WithMaxRetries(max uint64, next Backoff) Backoff {
 	var l sync.Mutex

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -198,6 +198,86 @@ func ExampleWithJitterPercent() {
 	}
 }
 
+func TestWithFullJitter(t *testing.T) {
+	t.Parallel()
+
+	for range 100_000 {
+		b := retry.WithFullJitter(retry.BackoffFunc(func() (time.Duration, bool) {
+			return 1 * time.Second, false
+		}))
+		val, stop := b.Next()
+		if stop {
+			t.Errorf("should not stop")
+		}
+
+		if min, max := time.Duration(0), 1*time.Second; val < min || val >= max {
+			t.Errorf("expected %v to be in [%v, %v)", val, min, max)
+		}
+	}
+}
+
+func TestWithFullJitter_NonPositive(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		nextVal  time.Duration
+		nextStop bool
+		wantVal  time.Duration
+		wantStop bool
+	}{
+		{
+			name:    "zero",
+			nextVal: 0,
+			wantVal: 0,
+		},
+		{
+			name:    "negative",
+			nextVal: -5 * time.Second,
+			wantVal: -5 * time.Second,
+		},
+		{
+			name:     "stop_propagates",
+			nextStop: true,
+			wantStop: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// A non-positive base must not panic (rand.Int64N panics on a
+			// non-positive argument) and must return the value unchanged.
+			b := retry.WithFullJitter(retry.BackoffFunc(func() (time.Duration, bool) {
+				return tc.nextVal, tc.nextStop
+			}))
+
+			val, stop := b.Next()
+			if stop != tc.wantStop {
+				t.Errorf("expected stop to be %t", tc.wantStop)
+			}
+			if val != tc.wantVal {
+				t.Errorf("expected %v to be %v", val, tc.wantVal)
+			}
+		})
+	}
+}
+
+func ExampleWithFullJitter() {
+	ctx := context.Background()
+
+	b := retry.NewFibonacci(1 * time.Second)
+	b = retry.WithFullJitter(b)
+
+	if err := retry.Do(ctx, b, func(_ context.Context) error {
+		// TODO: logic here
+		return nil
+	}); err != nil {
+		// handle error
+	}
+}
+
 func TestWithMaxRetries(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds a `WithFullJitter` backoff middleware, requested by @craigpastro.

Full jitter returns a random duration in `[0, base)`, where `base` is the wrapped backoff's value. Unlike `WithJitter` (`+/- j`) and `WithJitterPercent` (`+/- j%`), which keep the wait clustered around the base value, full jitter spreads it across the whole range. Per https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/, that decorrelates retrying clients more effectively.

```go
b := retry.NewFibonacci(1 * time.Second)
b = retry.WithFullJitter(b)
```

It reuses the lock-free `math/rand/v2` generator and, like the other jitter middlewares, propagates a stop and returns a non-positive base unchanged (so `rand.Int64N` never sees `n <= 0`). Tests cover the `[0, base)` range over 100k draws, the zero/negative/stop edges, plus a godoc example.

Closes https://github.com/sethvargo/go-retry/issues/21
